### PR TITLE
Add eslint-plugin-require-extensions to the eslint config

### DIFF
--- a/base.js
+++ b/base.js
@@ -5,15 +5,13 @@ module.exports = {
   },
   ignorePatterns: ["dist/**", "lib/**"],
   parser: "@typescript-eslint/parser",
-  plugins: [
-    "@typescript-eslint",
-    'simple-import-sort',
-  ],
+  extends: ["plugin:require-extensions/recommended"],
+  plugins: ["@typescript-eslint", "simple-import-sort", "require-extensions"],
   parserOptions: {
     sourceType: "module",
   },
   rules: {
     "simple-import-sort/imports": "error",
     "sort-keys-fix/sort-keys-fix": "error",
-  }
+  },
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 const base = require("./base.js");
 module.exports = {
   ...base,
-  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  extends: [
+    ...base.extends,
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+  ],
   plugins: [...base.plugins, "sort-keys-fix"],
   rules: {
     ...base.rules,

--- a/jest.js
+++ b/jest.js
@@ -5,7 +5,11 @@ module.exports = {
   overrides: [
     {
       files: ["**/__tests__/*.ts"],
-      extends: ["plugin:jest/recommended", "plugin:jest/style"],
+      extends: [
+        ...base.extends,
+        "plugin:jest/recommended",
+        "plugin:jest/style",
+      ],
       plugins: ["jest"],
       rules: {
         "jest/consistent-test-it": "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/eslint-config-solana",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "ESLint rules to be shared across all Solana Labs projects",
   "main": "index.js",
   "exports": {
@@ -31,6 +31,7 @@
     "eslint": "^8.45.0",
     "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-require-extensions": "^0.1.3",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-sort-keys-fix": "^1.1.2",
     "typescript": "^5.1.6"

--- a/react.js
+++ b/react.js
@@ -1,5 +1,5 @@
 const base = require("./base.js");
 module.exports = {
   ...base,
-  extends: ["plugin:react-hooks/recommended"],
+  extends: [...base.extends, "plugin:react-hooks/recommended"],
 };


### PR DESCRIPTION
See https://github.com/solana-labs/eslint-plugin-require-extensions

This PR adds the `require-extensions` to the eslint config, which enforces `.js` extensions on relative imports/exports
