### PR TITLE
docs: add deprecation notice pointing to @solana-foundation/js-configs

### DIFF
--- a/.changeset/major-frogs-taste.md
+++ b/.changeset/major-frogs-taste.md
@@ -1,0 +1,5 @@
+---
+"@solana/eslint-config-solana": patch
+---
+
+Deprecate this package in favor of `@solana-config/eslint` from the `@solana-foundation/js-configs` monorepo. Added a deprecation notice to the README.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Solana ESLint config
 
+> [!WARNING]
+> **This package is deprecated.** It has been replaced by
+> [`@solana-config/eslint`](https://github.com/solana-foundation/js-configs),
+> part of the [`@solana-foundation/js-configs`](https://github.com/solana-foundation/js-configs)
+> monorepo. Please migrate to the new package; this one will no longer receive updates.
+
 Let's share this ESLint config across all of our projects, to keep things consistent.
 
 ## Installation


### PR DESCRIPTION
This PR adds a deprecation notice to the README, since this package has been replaced by `@solana-config/eslint`, part of the [`@solana-foundation/js-configs`](https://github.com/solana-foundation/js-configs) monorepo. A changeset is included so the package re-publishes to NPM with the notice visible there, ahead of the eventual `npm deprecate`.